### PR TITLE
fix: avoid spurious re-fetch of already-cached candles on end="now" startup

### DIFF
--- a/qtradex/public/data.py
+++ b/qtradex/public/data.py
@@ -244,6 +244,21 @@ class Data:
         rev_index_key = str((self.exchange, self.pool, candle_size, currency, asset))
         total_time = [self.begin, self.end]
         raw_candles = None
+        # Whether this call actually hit the network. Only then can raw_candles'
+        # newest candle be still-forming and need cropping; on a pure cache hit
+        # it's already the correctly-cropped data from the last write.
+        did_fetch = False
+
+        # self.end (rounded up to a candle boundary in __init__) is usually
+        # ahead of the last candle that could have actually closed, so on
+        # every end="now" startup the cache looked "stale" against self.end
+        # even when nothing new had closed, forcing a pointless re-fetch/merge
+        # of already-cached candles. effective_end is the last genuinely
+        # closed candle boundary and is used only for the cache-freshness
+        # checks below; gather ranges and the final clip still use self.end so
+        # a real gap is still filled all the way to "now".
+        last_closed_candle = math.floor(time.time() / candle_size) * candle_size - candle_size
+        effective_end = min(self.end, last_closed_candle)
         # if the exchange hasn't been queried before for this pair or its inverse
         if index_key not in index and rev_index_key not in index:
             # gather data
@@ -254,6 +269,7 @@ class Data:
             raw_candles = self.gather_data(
                 candle_size, self.begin, self.end, asset, currency
             )
+            did_fetch = True
         else:
             inverted = rev_index_key in index
             index_key = rev_index_key if inverted else index_key
@@ -282,7 +298,7 @@ class Data:
                 min_time.pop(index_key, None)
 
             # within the range of what we need
-            elif time_range[0] > self.begin and time_range[1] < self.end:
+            elif time_range[0] > self.begin and time_range[1] < effective_end:
                 # Make two queries to get the data "around" what we already have
                 gather = [
                     [self.begin, time_range[0] + candle_size],
@@ -291,17 +307,17 @@ class Data:
                 use_cache = True  # time_range[:]
 
             # covers the end of what we need but not the beginning
-            elif time_range[0] > self.begin and time_range[1] >= self.end:
+            elif time_range[0] > self.begin and time_range[1] >= effective_end:
                 gather = [[self.begin, time_range[0] + candle_size]]
                 use_cache = True  # [time_range[0], self.end]
 
             # covers the beginning of what we need but not the end
-            elif time_range[0] <= self.begin and time_range[1] < self.end:
+            elif time_range[0] <= self.begin and time_range[1] < effective_end:
                 gather = [[time_range[1] - candle_size, self.end]]
                 use_cache = True  # [self.begin, time_range[1]]
 
             # all of what we need and potentially more
-            elif time_range[0] <= self.begin and time_range[1] >= self.end:
+            elif time_range[0] <= self.begin and time_range[1] >= effective_end:
                 use_cache = True  # [self.begin, self.end]
 
             else:
@@ -311,11 +327,18 @@ class Data:
 
             data = []
             if DETAIL:
+                cache_status = (
+                    "HIT (cache already covers request, no fetch needed)"
+                    if gather is None
+                    else "MISS (fetching to fill gap)"
+                )
                 print(
-                    f"gather: {gather}  use_cache: {use_cache}  @ {candle_size}, {index_key}"
+                    f"cache {cache_status} -- gather: {gather}  use_cache: {use_cache}"
+                    f"  @ {candle_size}, {index_key}"
                 )
             # gather up data from the two sources
             if gather is not None:
+                did_fetch = True
                 for raw_batch in gather:
                     batch = [max(i, min_time.get(index_key, 0)) for i in raw_batch]
                     if batch[0] == batch[1]:
@@ -364,33 +387,38 @@ class Data:
             else:
                 total_time = [self.begin, self.end]
 
-        # write the new cache with all the data
+        # Only rewrite the cache when we actually fetched something new --
+        # on a pure cache hit, raw_candles is already the correctly-cropped
+        # on-disk data, so re-running the crop below would erroneously trim
+        # a real, already-closed candle off the cache every time.
+        if did_fetch:
+            # write the new cache with all the data
 
-        # if the last candle is incomplete, don't cache it
-        crop = -1 if time.time() - self.end < candle_size else None
-        if crop is not None and DETAIL:
-            print("Cropping last (incomplete) candle from the cache...")
-        # convert numpy arrays to lists and crop if required
-        cache = {k: v[:crop].tolist() for k, v in raw_candles.items()}
-        # find the actual start and end of the cached data
-        try:
-            total_time = [min(cache["unix"]), max(cache["unix"])]
-        except (KeyError, ValueError, TypeError) as e:
-            raise TimeoutError(
-                f"{self.exchange} does not provide data for this time range."
-            ) from e
-        # cache it
-        json_ipc(f"{index_key} candles.json", json.dumps(cache))
+            # if the last candle is incomplete, don't cache it
+            crop = -1 if time.time() - self.end < candle_size else None
+            if crop is not None and DETAIL:
+                print("Cropping last (incomplete) candle from the cache...")
+            # convert numpy arrays to lists and crop if required
+            cache = {k: v[:crop].tolist() for k, v in raw_candles.items()}
+            # find the actual start and end of the cached data
+            try:
+                total_time = [min(cache["unix"]), max(cache["unix"])]
+            except (KeyError, ValueError, TypeError) as e:
+                raise TimeoutError(
+                    f"{self.exchange} does not provide data for this time range."
+                ) from e
+            # cache it
+            json_ipc(f"{index_key} candles.json", json.dumps(cache))
+
+            # stow the start and end in the index
+            if total_time is not None:
+                index[index_key] = total_time
+                json_ipc("data_index.json", json.dumps(index))
 
         # clip the return data to the requested amount
         raw_candles = clip_to_time_range(raw_candles, self.begin, self.end)
 
         json_ipc("min_time.json", json.dumps(min_time))
-
-        # stow the start and end in the index
-        if total_time is not None:
-            index[index_key] = total_time
-            json_ipc("data_index.json", json.dumps(index))
 
         return raw_candles
 

--- a/qtradex/public/tests/test_data_cache.py
+++ b/qtradex/public/tests/test_data_cache.py
@@ -1,0 +1,207 @@
+"""
+Regression tests for the disk-based candle cache in `qtradex.public.data.Data`.
+
+Covers upstream issue #3 ("[Help Wanted] Debug data caching"): startups with
+`end="now"` should not spuriously re-fetch / re-merge candles that are
+already fully cached and unchanged, just because `self.end` gets rounded to a
+candle boundary that sits ahead of the last candle that could possibly have
+closed. Genuinely stale caches must still be topped up correctly.
+
+No network calls are made: `Data.gather_data` is patched out entirely (and
+asserted to be called, or not called, depending on the scenario), and the
+JSON cache pipe (`qtradex.public.data.json_ipc`) is patched with an in-memory
+stand-in so the tests never touch the real `qtradex/common/pipe` cache files
+on disk.
+"""
+
+import json
+import math
+import time
+import unittest
+from unittest import mock
+
+import numpy as np
+
+from qtradex.public.data import Data
+
+
+def _make_fake_json_ipc(store):
+    """
+    A tiny in-memory stand-in for `qtradex.common.json_ipc.json_ipc`, so
+    tests never touch the real on-disk cache pipe.
+    """
+
+    def fake_json_ipc(doc="", text=None, initialize=False, append=False):
+        if text is not None:
+            store[doc] = text
+            return None
+        if doc in store:
+            return json.loads(store[doc])
+        raise FileNotFoundError(doc)
+
+    return fake_json_ipc
+
+
+def _make_candles(start, count, candle_size, price=100.0):
+    unix = [start + i * candle_size for i in range(count)]
+    return {
+        "unix": unix,
+        "open": [price] * count,
+        "high": [price + 1] * count,
+        "low": [price - 1] * count,
+        "close": [price] * count,
+        "volume": [10.0] * count,
+    }
+
+
+class DataCacheTest(unittest.TestCase):
+    def setUp(self):
+        self.candle_size = 3600  # 1 hour, for a fast-running test
+        self.exchange = "faketestexchange"
+        self.asset = "AAA"
+        self.currency = "BBB"
+        self.index_key = str(
+            (self.exchange, None, self.candle_size, self.asset, self.currency)
+        )
+
+        # The most recent candle that could genuinely have finished closing
+        # right now.
+        now_boundary = math.floor(time.time() / self.candle_size) * self.candle_size
+        self.last_closed = now_boundary - self.candle_size
+
+        self.store = {}
+        self.json_ipc_patcher = mock.patch(
+            "qtradex.public.data.json_ipc", new=_make_fake_json_ipc(self.store)
+        )
+        self.json_ipc_patcher.start()
+        self.addCleanup(self.json_ipc_patcher.stop)
+
+    def _seed_cache(self, first_candle_count=24):
+        """
+        Seed the fake cache pipe with `first_candle_count` hourly candles
+        ending exactly at the last candle that could possibly have closed --
+        i.e. a cache that is already fully current.
+        """
+        begin = self.last_closed - (first_candle_count - 1) * self.candle_size
+        candles = _make_candles(begin, first_candle_count, self.candle_size)
+        self.store[f"{self.index_key} candles.json"] = json.dumps(candles)
+        self.store["data_index.json"] = json.dumps(
+            {self.index_key: [begin, self.last_closed]}
+        )
+        self.store["min_time.json"] = json.dumps({})
+        return begin
+
+    def test_up_to_date_cache_does_not_refetch(self):
+        """
+        The core regression test for upstream issue #3: re-initializing Data
+        with end="now" shortly after the cache was already brought fully
+        current must not trigger any network fetch, and must not add any
+        "new" candles beyond what was genuinely already cached.
+        """
+        begin = self._seed_cache(first_candle_count=24)
+
+        with mock.patch.object(
+            Data,
+            "gather_data",
+            side_effect=AssertionError(
+                "gather_data should not be called when the cache is already current"
+            ),
+        ) as gather_mock:
+            data = Data(
+                exchange=self.exchange,
+                asset=self.asset,
+                currency=self.currency,
+                begin=begin,
+                end=None,
+                candle_size=self.candle_size,
+            )
+
+        gather_mock.assert_not_called()
+        # exactly the 24 candles that were already cached -- nothing dropped,
+        # nothing spuriously duplicated/added.
+        self.assertEqual(len(data.raw_candles["unix"]), 24)
+        self.assertEqual(int(data.raw_candles["unix"][-1]), self.last_closed)
+
+    def test_repeated_up_to_date_calls_do_not_shrink_cache(self):
+        """
+        Regression test for a second bug the naive fix would otherwise
+        surface: on a pure cache hit, the "crop the incomplete trailing
+        candle" logic must not run against already-cached (already correctly
+        cropped) data, or the cache would lose one real candle every time
+        Data is re-initialized with end="now" and nothing new has closed.
+        """
+        begin = self._seed_cache(first_candle_count=24)
+
+        with mock.patch.object(
+            Data, "gather_data", side_effect=AssertionError("should not fetch")
+        ):
+            Data(
+                exchange=self.exchange,
+                asset=self.asset,
+                currency=self.currency,
+                begin=begin,
+                end=None,
+                candle_size=self.candle_size,
+            )
+            cache_after_first = json.loads(
+                self.store[f"{self.index_key} candles.json"]
+            )
+
+            Data(
+                exchange=self.exchange,
+                asset=self.asset,
+                currency=self.currency,
+                begin=begin,
+                end=None,
+                candle_size=self.candle_size,
+            )
+            cache_after_second = json.loads(
+                self.store[f"{self.index_key} candles.json"]
+            )
+
+        self.assertEqual(len(cache_after_first["unix"]), 24)
+        self.assertEqual(cache_after_first, cache_after_second)
+
+    def test_genuinely_stale_cache_still_gets_topped_up(self):
+        """
+        Control test: when the cache is genuinely behind (several real
+        candles have closed since it was last updated), a fetch must still
+        happen and the new candles must be merged in.
+        """
+        # cache is 5 candles behind the last closed candle
+        stale_last = self.last_closed - 5 * self.candle_size
+        begin = stale_last - 23 * self.candle_size
+        candles = _make_candles(begin, 24, self.candle_size)
+        self.store[f"{self.index_key} candles.json"] = json.dumps(candles)
+        self.store["data_index.json"] = json.dumps(
+            {self.index_key: [begin, stale_last]}
+        )
+        self.store["min_time.json"] = json.dumps({})
+
+        # overlap candle + 5 genuinely new ones
+        new_candles = _make_candles(stale_last, 6, self.candle_size)
+
+        def fake_gather(self_, candle_size, gather_begin, gather_end, asset, currency):
+            return {k: np.array(v) for k, v in new_candles.items()}
+
+        with mock.patch.object(
+            Data, "gather_data", autospec=True, side_effect=fake_gather
+        ) as gather_mock:
+            data = Data(
+                exchange=self.exchange,
+                asset=self.asset,
+                currency=self.currency,
+                begin=begin,
+                end=None,
+                candle_size=self.candle_size,
+            )
+
+        gather_mock.assert_called()
+        # old candles + 5 genuinely new ones, no duplicates
+        unix_values = sorted(int(u) for u in data.raw_candles["unix"])
+        self.assertEqual(len(unix_values), len(set(unix_values)))
+        self.assertEqual(unix_values[-1], self.last_closed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3.

## Root cause

`self.end` gets rounded *up* to a candle boundary in `Data.__init__` (so a user-supplied end date is never truncated). When the caller uses the default `end="now"`, that rounding routinely lands one candle past the most recent candle that could actually have closed. The cache-freshness checks in `retrieve_and_cache_candles` compared the cache's last known candle directly against this inflated `self.end`, so the cache looked "stale" on *every* startup even when nothing new had closed -- triggering a real re-fetch/merge of candles that were already cached. That's the "7-9 new candles that aren't actually new" from the issue.

## Fix

- Added `effective_end`: the boundary of the last candle that has genuinely finished closing, clamped to whatever the caller requested. It's used only for the cache-freshness checks (the four branches that decide whether/what to `gather`); the actual gather ranges and the final clip still use `self.end`, so a real gap is still filled all the way to "now" (including picking up the live, still-forming candle when one is actually warranted).
- Skip re-writing the cache file / index and re-cropping the "incomplete trailing candle" on a pure cache hit (no `gather` performed) -- the on-disk data was already correctly cropped when it was originally written, so re-running that crop on every cache-hit run was silently trimming one real, already-closed candle off the cache each time.
- Added `DETAIL`-gated cache hit/miss logging alongside the existing gather/use_cache debug print (bonus item from the issue).

## Tests

Added `qtradex/public/tests/test_data_cache.py` (network calls mocked out via `Data.gather_data` and an in-memory `json_ipc` stand-in):
- an up-to-date cache does not trigger a fetch and returns exactly the cached candles
- repeated end="now" initializations against an up-to-date cache do not shrink/alter the cache
- a genuinely stale cache is still correctly topped up with new candles

Not included: dedicated cache verification/integrity tests beyond the above, since the issue's other "bonus" ask (integrity tests) overlaps significantly with the regression tests already added here.